### PR TITLE
aodn/aodn-portal#1406 - use CRS:84 which actually has lon/lat coordinate...

### DIFF
--- a/extension/imos--1.0.sql
+++ b/extension/imos--1.0.sql
@@ -272,12 +272,17 @@ $BODY$
 LANGUAGE plpgsql; 
 
 -- Function to return a bounding polygon as gml 3
+-- Use CRS:84 with lon/lat ordering rather than default EPSG:4326 with incorrect lon/lat ordering
 
 CREATE FUNCTION BoundingPolygonAsGml3(p_schema_name text, p_table_name text, p_column_name text, p_resolution double precision)
     RETURNS text AS
 $BODY$
+DECLARE
+    GML_3_1_1 CONSTANT integer := 3; -- GML version
+    boundingPolygonAsGml text;
 BEGIN
-    RETURN ST_AsGml(3, BoundingPolygon(p_schema_name, p_table_name, p_column_name, p_resolution));
+    boundingPolygonAsGml := ST_AsGml(GML_3_1_1, BoundingPolygon(p_schema_name, p_table_name, p_column_name, p_resolution));
+    RETURN replace(boundingPolygonAsGml, 'EPSG:4326', 'CRS:84');
 END;
 $BODY$
 LANGUAGE plpgsql; 

--- a/test/BoundingPolygonAsGml3.sql
+++ b/test/BoundingPolygonAsGml3.sql
@@ -22,7 +22,7 @@ SELECT plan(2);
 
 SELECT is( 
     BoundingPolygonAsGml3(current_schema, 'test_data', 'position', 1),
-    '<gml:MultiSurface srsName="EPSG:4326"><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">1 41 1 42 2 42 2 41 1 41</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">7 43 7 44 8 44 8 43 7 43</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">3 44 3 45 4 45 4 46 5 46 5 44 3 44</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface>',
+    '<gml:MultiSurface srsName="CRS:84"><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">1 41 1 42 2 42 2 41 1 41</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">7 43 7 44 8 44 8 43 7 43</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">3 44 3 45 4 45 4 46 5 46 5 44 3 44</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface>',
     'Should make 3 polygons at 1 degree resolution'
 );
 
@@ -30,7 +30,7 @@ SELECT is(
 
 SELECT is( 
     BoundingPolygonAsGml3(current_schema, 'test_data', 'position', 10),
-    '<gml:Polygon srsName="EPSG:4326"><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">0 40 0 50 10 50 10 40 0 40</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>',
+    '<gml:Polygon srsName="CRS:84"><gml:exterior><gml:LinearRing><gml:posList srsDimension="2">0 40 0 50 10 50 10 40 0 40</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>',
     'Should make 1 polygon at 10 degree resolution'
 );
 


### PR DESCRIPTION
... ordering rather than the default EPSG:4326 which doesn't

DO NOT MERGE UNTIL NEXT ITERATION

To be tested next iteration in content staging prior to release to production.  

Requires spatial extent update to be run in content staging after changes have been made/harvesters to run to update spatial extent to include the required SRS. 
