### PR TITLE
Fix ST_LineInterpolatePoint function name

### DIFF
--- a/extension/imos--1.0.sql
+++ b/extension/imos--1.0.sql
@@ -149,7 +149,7 @@ BEGIN
     SELECT INTO shifted ST_ShiftLongitude(st_makeline(pointa, pointb));
     SELECT INTO pointashifted ST_ShiftLongitude(pointa);
     SELECT INTO pointbshifted ST_ShiftLongitude(pointb);
-    SELECT INTO meridian_intersection ST_Line_InterpolatePoint(shifted, (180 - st_x(pointashifted)) / (st_x(pointbshifted) - st_x(pointashifted)));
+    SELECT INTO meridian_intersection ST_LineInterpolatePoint(shifted, (180 - st_x(pointashifted)) / (st_x(pointbshifted) - st_x(pointashifted)));
     SELECT INTO meridian_intersection_unshifted st_translate(meridian_intersection, -360, 0);
 
     IF (st_x(pointa) < 0) THEN


### PR DESCRIPTION
The previous rename didn't remove enough underscores! The desired function name is:
https://postgis.net/docs/ST_LineInterpolatePoint.html

