### PR TITLE
Add downgrade path from 1.1 to 1.0

### DIFF
--- a/extension/imos--1.1--1.0.sql
+++ b/extension/imos--1.1--1.0.sql
@@ -1,0 +1,37 @@
+/* contrib/imos/imos--1.1--1.0.sql
+
+   ## To manually downgrade from 1.1 to 1.0
+   ALTER EXTENSION imos UPDATE to '1.0'
+
+   ## Fresh installation installs the version in imos.control
+
+*/
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION imos UPDATE to 1.0 to load this file if on version 1.1." \quit
+
+
+ALTER FUNCTION getendtoken(character,  character,  integer) RESET search_path;
+ALTER FUNCTION format_name(character) RESET search_path;
+ALTER FUNCTION add_point_shortest(geometry,geometry) RESET search_path;
+ALTER FUNCTION make_trajectory(geometry,geometry) RESET search_path;
+ALTER FUNCTION is_valid_point(geometry) RESET search_path;
+ALTER FUNCTION make_point_or_shortest_line(geometry,geometry) RESET search_path;
+ALTER FUNCTION make_line_crossing_antimeridian(geometry,geometry) RESET search_path;
+ALTER FUNCTION make_shortest_line(geometry,geometry) RESET search_path;
+ALTER FUNCTION st_createfishnet(integer, integer, double precision, double precision, double precision, double precision, integer) RESET search_path;
+ALTER FUNCTION create_grid_cells(double precision) RESET search_path;
+ALTER FUNCTION BoundingPolygon(text,text,text,double precision) RESET search_path;
+ALTER FUNCTION add_id_to_polygons(text ) RESET search_path;
+ALTER FUNCTION BoundingPolygonAsGml3(text,text,text,double precision) RESET search_path;
+ALTER FUNCTION MakePoint(float8, float8) RESET search_path;
+ALTER FUNCTION MakePoint(float8, float8, float8) RESET search_path;
+ALTER FUNCTION MakePoint(float8, float8, float8, float8) RESET search_path;
+ALTER FUNCTION GeomFromText(text, int4) RESET search_path;
+ALTER FUNCTION GeomFromText(text) RESET search_path;
+ALTER FUNCTION exec(text) RESET search_path;
+ALTER FUNCTION drop_objects_in_schema(schema text) RESET search_path;
+ALTER FUNCTION database_activity() RESET search_path;
+
+
+


### PR DESCRIPTION
Just thought of the scenario where a backout is required for some reason. This enables you to switch in both directions between 1.0 and 1.1.


```bash
harvest=# \sf database_activity
CREATE OR REPLACE FUNCTION public.database_activity()
 RETURNS SETOF pg_stat_activity
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$ SELECT * FROM pg_catalog.pg_stat_activity; $function$

harvest=# ALTER EXTENSION imos UPDATE to '1.0';
ALTER EXTENSION
harvest=# \sf database_activity
CREATE OR REPLACE FUNCTION public.database_activity()
 RETURNS SETOF pg_stat_activity
 LANGUAGE sql
 SECURITY DEFINER
AS $function$ SELECT * FROM pg_catalog.pg_stat_activity; $function$

harvest=# ALTER EXTENSION imos UPDATE to '1.1';
ALTER EXTENSION
harvest=# \sf database_activity
CREATE OR REPLACE FUNCTION public.database_activity()
 RETURNS SETOF pg_stat_activity
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path TO 'public'
AS $function$ SELECT * FROM pg_catalog.pg_stat_activity; $function$

```